### PR TITLE
Remove entity package and move MaritimePort struct under portsmanaging package.

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -53,12 +53,12 @@ const docTemplate = `{
                 "summary": "Create a new port or update an existing one.",
                 "parameters": [
                     {
-                        "description": "Port Entry",
+                        "description": "MaritimePort Entry",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/entity.Port"
+                            "$ref": "#/definitions/portsmanaging.MaritimePort"
                         }
                     }
                 ],
@@ -81,7 +81,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Port ID",
+                        "description": "MaritimePort ID",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -92,7 +92,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "entity.Port": {
+        "portsmanaging.MaritimePort": {
             "type": "object",
             "properties": {
                 "alias": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -46,12 +46,12 @@
                 "summary": "Create a new port or update an existing one.",
                 "parameters": [
                     {
-                        "description": "Port Entry",
+                        "description": "MaritimePort Entry",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/entity.Port"
+                            "$ref": "#/definitions/portsmanaging.MaritimePort"
                         }
                     }
                 ],
@@ -74,7 +74,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Port ID",
+                        "description": "MaritimePort ID",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -85,7 +85,7 @@
         }
     },
     "definitions": {
-        "entity.Port": {
+        "portsmanaging.MaritimePort": {
             "type": "object",
             "properties": {
                 "alias": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,6 +1,6 @@
 basePath: /
 definitions:
-  entity.Port:
+  portsmanaging.MaritimePort:
     properties:
       alias:
         items:
@@ -62,12 +62,12 @@ paths:
       - application/json
       description: Create a new port or update an existing one.
       parameters:
-      - description: Port Entry
+      - description: MaritimePort Entry
         in: body
         name: request
         required: true
         schema:
-          $ref: '#/definitions/entity.Port'
+          $ref: '#/definitions/portsmanaging.MaritimePort'
       produces:
       - application/json
       responses: {}
@@ -80,7 +80,7 @@ paths:
       - application/json
       description: Get an existing port by ID.
       parameters:
-      - description: Port ID
+      - description: MaritimePort ID
         in: path
         name: id
         required: true

--- a/pkg/handlers/ports_handler.go
+++ b/pkg/handlers/ports_handler.go
@@ -7,17 +7,17 @@ import (
 	"io"
 	"net/http"
 
-	pkgErrors "github.com/pkg/errors"
-	"github.com/powerslider/maritime-ports-service/pkg/entity"
+	"github.com/powerslider/maritime-ports-service/pkg/portsmanaging"
 
 	"github.com/gorilla/mux"
+	pkgErrors "github.com/pkg/errors"
 )
 
-// PortsService is a port interface for operations on entity.Port.
+// PortsService is a port interface for operations on portsmanaging.MaritimePort.
 type PortsService interface {
-	GetAllPorts() ([]*entity.Port, error)
-	GetPortByID(ID string) (*entity.Port, error)
-	CreateOrUpdatePort(p *entity.Port) (*entity.Port, bool, error)
+	GetAllPorts() ([]*portsmanaging.MaritimePort, error)
+	GetPortByID(ID string) (*portsmanaging.MaritimePort, error)
+	CreateOrUpdatePort(p *portsmanaging.MaritimePort) (*portsmanaging.MaritimePort, bool, error)
 }
 
 // PortsHandler represents an HTTP handler for Ethereum block operations.
@@ -41,7 +41,7 @@ func NewPortsHandler(service PortsService) *PortsHandler {
 // @Router /api/v1/ports [get]
 func (h *PortsHandler) GetAllPorts() http.HandlerFunc {
 	type response struct {
-		Result []*entity.Port `json:"result"`
+		Result []*portsmanaging.MaritimePort `json:"result"`
 	}
 
 	return func(rw http.ResponseWriter, r *http.Request) {
@@ -67,11 +67,11 @@ func (h *PortsHandler) GetAllPorts() http.HandlerFunc {
 // @Tags ports
 // @Accept  json
 // @Produce  json
-// @Param id path string true "Port ID"
+// @Param id path string true "MaritimePort ID"
 // @Router /api/v1/ports/{id} [get]
 func (h *PortsHandler) GetPort() http.HandlerFunc {
 	type response struct {
-		Result *entity.Port `json:"result"`
+		Result *portsmanaging.MaritimePort `json:"result"`
 	}
 
 	return func(rw http.ResponseWriter, r *http.Request) {
@@ -118,7 +118,7 @@ func (h *PortsHandler) GetPort() http.HandlerFunc {
 // @Tags ports
 // @Accept  json
 // @Produce  json
-// @Param request body entity.Port true "Port Entry"
+// @Param request body portsmanaging.MaritimePort true "MaritimePort Entry"
 // @Router /api/v1/ports [post]
 func (h *PortsHandler) CreateOrUpdatePort() http.HandlerFunc {
 	type response struct {
@@ -128,7 +128,7 @@ func (h *PortsHandler) CreateOrUpdatePort() http.HandlerFunc {
 	}
 
 	return func(rw http.ResponseWriter, r *http.Request) {
-		var reqBody entity.Port
+		var reqBody portsmanaging.MaritimePort
 
 		reqBytes, errReqBytes := io.ReadAll(r.Body)
 		errReqUnmarshal := json.Unmarshal(reqBytes, &reqBody)

--- a/pkg/portsmanaging/json_loader.go
+++ b/pkg/portsmanaging/json_loader.go
@@ -9,8 +9,6 @@ import (
 	"path/filepath"
 
 	pkgErrors "github.com/pkg/errors"
-
-	"github.com/powerslider/maritime-ports-service/pkg/entity"
 )
 
 // JSONLoader is a service responsible for loading json data.
@@ -61,7 +59,7 @@ func (l *JSONLoader) Load(r io.Reader) error {
 			return pkgErrors.WithStack(err)
 		}
 
-		var p entity.Port
+		var p MaritimePort
 
 		err = dec.Decode(&p)
 		if err != nil {

--- a/pkg/portsmanaging/json_loader_test.go
+++ b/pkg/portsmanaging/json_loader_test.go
@@ -5,15 +5,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/powerslider/maritime-ports-service/pkg/entity"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/powerslider/maritime-ports-service/pkg/portsmanaging"
 	"github.com/powerslider/maritime-ports-service/pkg/storage/memory"
 )
 
-var expectedPorts = map[string]*entity.Port{
+var expectedPorts = map[string]*portsmanaging.MaritimePort{
 	"AEAJM": {
 		ID:          "AEAJM",
 		Name:        "Ajman",

--- a/pkg/portsmanaging/maritime_port.go
+++ b/pkg/portsmanaging/maritime_port.go
@@ -1,7 +1,7 @@
-package entity
+package portsmanaging
 
-// Port represents a maritime port.
-type Port struct {
+// MaritimePort represents a maritime port.
+type MaritimePort struct {
 	ID          string    `json:"id"`
 	Name        string    `json:"name"`
 	City        string    `json:"city"`

--- a/pkg/portsmanaging/ports.go
+++ b/pkg/portsmanaging/ports.go
@@ -1,14 +1,13 @@
 package portsmanaging
 
-import "github.com/powerslider/maritime-ports-service/pkg/entity"
-
-// PortsStore is a port interface representing operations on entity.Port entity.
+// PortsStore is a port interface representing operations on portsmanaging.MaritimePort entity.
 type PortsStore interface {
-	UpsertPort(port *entity.Port) (*entity.Port, bool, error)
+	// UpsertPort inserts or modifies a new/existing portsmanaging.MaritimePort entity.
+	UpsertPort(port *MaritimePort) (*MaritimePort, bool, error)
 
-	// GetAllPorts returns all available ports from type entity.Port.
-	GetAllPorts() ([]*entity.Port, error)
+	// GetAllPorts returns all available ports from type portsmanaging.MaritimePort.
+	GetAllPorts() ([]*MaritimePort, error)
 
-	// GetPortByID returns an entity.Port identified by an available ID.
-	GetPortByID(id string) (*entity.Port, error)
+	// GetPortByID returns n portsmanaging.MaritimePort identified by an available ID.
+	GetPortByID(id string) (*MaritimePort, error)
 }

--- a/pkg/portsmanaging/service.go
+++ b/pkg/portsmanaging/service.go
@@ -1,10 +1,6 @@
 package portsmanaging
 
-import (
-	"github.com/powerslider/maritime-ports-service/pkg/entity"
-)
-
-// Service represents execution of business logic upon entity.Port.
+// Service represents execution of business logic upon portsmanaging.MaritimePort.
 type Service struct {
 	Repository PortsStore
 }
@@ -16,17 +12,17 @@ func NewService(repository PortsStore) *Service {
 	}
 }
 
-// GetAllPorts returns all ports of type entity.Port stored in the system.
-func (h *Service) GetAllPorts() ([]*entity.Port, error) {
+// GetAllPorts returns all ports of type portsmanaging.MaritimePort stored in the system.
+func (h *Service) GetAllPorts() ([]*MaritimePort, error) {
 	return h.Repository.GetAllPorts()
 }
 
 // GetPortByID returns a porn given a port ID.
-func (h *Service) GetPortByID(ID string) (*entity.Port, error) {
+func (h *Service) GetPortByID(ID string) (*MaritimePort, error) {
 	return h.Repository.GetPortByID(ID)
 }
 
-// CreateOrUpdatePort add a new port entry of type entity.Port or updates an existing one.
-func (h *Service) CreateOrUpdatePort(p *entity.Port) (*entity.Port, bool, error) {
+// CreateOrUpdatePort add a new port entry of type portsmanaging.MaritimePort or updates an existing one.
+func (h *Service) CreateOrUpdatePort(p *MaritimePort) (*MaritimePort, bool, error) {
 	return h.Repository.UpsertPort(p)
 }

--- a/pkg/storage/memory/ports_repository.go
+++ b/pkg/storage/memory/ports_repository.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"sync"
 
-	pkgErrors "github.com/pkg/errors"
+	"github.com/powerslider/maritime-ports-service/pkg/portsmanaging"
 
-	"github.com/powerslider/maritime-ports-service/pkg/entity"
+	pkgErrors "github.com/pkg/errors"
 )
 
 // PortsRepository holds the CRUD db operations for CasinoRoundBet.
@@ -23,8 +23,8 @@ func NewPortsRepository() *PortsRepository {
 	}
 }
 
-// UpsertPort inserts a new entity.Port entity.
-func (r *PortsRepository) UpsertPort(port *entity.Port) (*entity.Port, bool, error) {
+// UpsertPort inserts or modifies a new/existing portsmanaging.MaritimePort entity.
+func (r *PortsRepository) UpsertPort(port *portsmanaging.MaritimePort) (*portsmanaging.MaritimePort, bool, error) {
 	p, loaded := r.store.LoadOrStore(port.ID, port)
 
 	if loaded {
@@ -36,7 +36,7 @@ func (r *PortsRepository) UpsertPort(port *entity.Port) (*entity.Port, bool, err
 				err, "error: failed update of existing port with ID '%s'", port.ID)
 		}
 
-		updatedPort, ok := p.(*entity.Port)
+		updatedPort, ok := p.(*portsmanaging.MaritimePort)
 		if !ok {
 			return nil, loaded, fmt.Errorf("error: updated port entry is corrupt: %s", fmt.Sprint(p))
 		}
@@ -46,17 +46,17 @@ func (r *PortsRepository) UpsertPort(port *entity.Port) (*entity.Port, bool, err
 		return updatedPort, loaded, nil
 	}
 
-	return p.(*entity.Port), loaded, nil
+	return p.(*portsmanaging.MaritimePort), loaded, nil
 }
 
-// GetAllPorts returns all available ports from type entity.Port.
-func (r *PortsRepository) GetAllPorts() ([]*entity.Port, error) {
+// GetAllPorts returns all available ports from type portsmanaging.MaritimePort.
+func (r *PortsRepository) GetAllPorts() ([]*portsmanaging.MaritimePort, error) {
 	var err error
 
-	pp := make([]*entity.Port, 0)
+	pp := make([]*portsmanaging.MaritimePort, 0)
 
 	r.store.Range(func(key, value any) bool {
-		p, ok := value.(*entity.Port)
+		p, ok := value.(*portsmanaging.MaritimePort)
 		if ok {
 			pp = append(pp, p)
 		} else {
@@ -69,11 +69,11 @@ func (r *PortsRepository) GetAllPorts() ([]*entity.Port, error) {
 	return pp, err
 }
 
-// GetPortByID returns an entity.Port identified by an available ID.
-func (r *PortsRepository) GetPortByID(id string) (*entity.Port, error) {
+// GetPortByID returns n portsmanaging.MaritimePort identified by an available ID.
+func (r *PortsRepository) GetPortByID(id string) (*portsmanaging.MaritimePort, error) {
 	v, loaded := r.store.Load(id)
 	if loaded {
-		p, ok := v.(*entity.Port)
+		p, ok := v.(*portsmanaging.MaritimePort)
 		if ok {
 			return p, nil
 		}


### PR DESCRIPTION
This PR contains the following changes:

- Removal of `entity` package because it does not comply well with DDD to have a centralized domain model.
- Rename `Port` struct to `MaritimePort` to avoid confusion with the term port in hex architecture.
- Move `MaritimePort` to `portsmanaging` package where it will be bound to the context of managing a maritime port and will represent a data model suited for that particular context.
- Fix some comments.
- Regenerate swagger docs.